### PR TITLE
✨ Feature: #18 CloudKit 데이터 학습 화면에 적용 

### DIFF
--- a/YOZM/YOZM/App/YOZMApp.swift
+++ b/YOZM/YOZM/App/YOZMApp.swift
@@ -20,7 +20,7 @@ struct YOZMApp: App {
 struct MainView: View {
     var body: some View {
         NavigationStack {
-            DevView()
+            ChapterView()
         }
     }
 }

--- a/YOZM/YOZM/Service/AudioPlayerService.swift
+++ b/YOZM/YOZM/Service/AudioPlayerService.swift
@@ -11,25 +11,30 @@ enum AudioPlayerServiceError: Error, LocalizedError {
     case playerIsNotInitialized
 }
 
-final class AudioPlayerService {
+final class AudioPlayerService: NSObject {
     static let shared = AudioPlayerService()
 
-    private init() {}
+    private override init() {
+        super.init()
+    }
 
     private(set) var isPlaying: Bool = false
     private(set) var currentTime: TimeInterval = 0.0
 
     private var player: AVAudioPlayer? = nil
+    
+    // 재생 완료를 위한 continuation
+    private var playbackContinuation: CheckedContinuation<Void, Never>?
 
     func load(url: URL) throws {
         let player = try AVAudioPlayer(contentsOf: url)
-
+        player.delegate = self
         self.player = player
     }
 
     func load(audioData: Data) throws {
         let player = try AVAudioPlayer(data: audioData)
-
+        player.delegate = self
         self.player = player
     }
 
@@ -41,6 +46,20 @@ final class AudioPlayerService {
         configureAudioSession()
         player.play()
         isPlaying = true
+    }
+    
+    func playAndWait() async throws {
+        guard let player else {
+            throw AudioPlayerServiceError.playerIsNotInitialized
+        }
+
+        configureAudioSession()
+        
+        return await withCheckedContinuation { continuation in
+            playbackContinuation = continuation
+            player.play()
+            isPlaying = true
+        }
     }
 
     func pause() throws {
@@ -60,6 +79,9 @@ final class AudioPlayerService {
         player.stop()
         player.currentTime = 0.0
         isPlaying = false
+        
+        playbackContinuation?.resume()
+        playbackContinuation = nil
     }
 
     func seek(to time: TimeInterval) throws {
@@ -78,6 +100,24 @@ final class AudioPlayerService {
             try session.setActive(true)
         } catch {
             print("Failed to set audio session")
+        }
+    }
+}
+
+// MARK: - AVAudioPlayerDelegate
+extension AudioPlayerService: AVAudioPlayerDelegate {
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        isPlaying = false
+        playbackContinuation?.resume()
+        playbackContinuation = nil
+    }
+    
+    func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
+        isPlaying = false
+        playbackContinuation?.resume()
+        playbackContinuation = nil
+        if let error = error {
+            print("Audio decode error: \(error)")
         }
     }
 }

--- a/YOZM/YOZM/Service/CloudKit/CloudKitAudioService.swift
+++ b/YOZM/YOZM/Service/CloudKit/CloudKitAudioService.swift
@@ -30,7 +30,17 @@ final class CloudKitAudioService {
     /// Word ID로 dialogue asset URL 배열 가져오기
     func fetchDialogueAudioURLs(wordId: Int64) async throws -> [URL] {
         let wordRecord = try await fetchWordRecord(by: wordId)
-        return try extractAudioURLs(from: wordRecord, fieldName: AudioType.dialogue.fieldName)
+        
+        let dialogueRecords = try await fetchDialogueRecords(for: wordRecord)
+
+        var audioURLs: [URL] = []
+        for dialogueRecord in dialogueRecords {
+            if let audioURL = try? extractAudioURL(from: dialogueRecord, fieldName: AudioType.dialogue.fieldName) {
+                audioURLs.append(audioURL)
+            }
+        }
+        
+        return audioURLs
     }
     
     /// Dialogue ID로 특정 dialogue asset URL 가져오기
@@ -47,7 +57,28 @@ final class CloudKitAudioService {
             throw CloudKitError.recordNotFound
         }
         
-        return try extractAudioURL(from: dialogueRecord, fieldName: "dialogueAudio")
+        return try extractAudioURL(from: dialogueRecord, fieldName: AudioType.dialogue.fieldName)
+    }
+    
+    private func fetchDialogueRecords(for wordRecord: CKRecord) async throws -> [CKRecord] {
+        let dialogueQuery = CKQuery(
+            recordType: CloudKitType.dialogueRecordType,
+            predicate: NSPredicate(format: "\(CloudKitField.wordReference.rawValue) == %@", wordRecord)
+        )
+        
+        let (results, _) = try await publicDatabase.records(matching: dialogueQuery)
+        
+        var dialogueRecords: [CKRecord] = []
+        for (_, result) in results {
+            switch result {
+            case .success(let record):
+                dialogueRecords.append(record)
+            case .failure:
+                throw CloudKitError.recordNotFound
+            }
+        }
+        
+        return dialogueRecords
     }
     
     private func fetchWordRecord(by wordId: Int64) async throws -> CKRecord {
@@ -81,7 +112,7 @@ final class CloudKitAudioService {
         guard let audioAssets = record[fieldName] as? [CKAsset] else {
             throw CloudKitError.audioDataNotFound
         }
-        
+ 
         return audioAssets.compactMap { $0.fileURL }
     }
 }

--- a/YOZM/YOZM/Service/CloudKit/CloudKitFetcherService.swift
+++ b/YOZM/YOZM/Service/CloudKit/CloudKitFetcherService.swift
@@ -102,13 +102,13 @@ final class CloudKitFetcherService {
         do {
             let stageRecords = try await fetchRecords(
                 recordType: CloudKitType.stageRecordType,
-                predicate: NSPredicate(format: "\(CloudKitField.chapterReference.rawValue) == %@", chapterRecord),
-                sortBy: CloudKitField.id.rawValue
+                predicate: NSPredicate(format: "\(CloudKitField.chapterReference.rawValue) == %@", chapterRecord)
             )
             
             let stages = try await processRecordsConcurrently(stageRecords, transform: buildStage)
+            let sortedStages = stages.sorted { $0.id < $1.id }
             print("[CloudKitFetcher] 스테이지 조회 완료 - 총 \(stages.count)개")
-            return stages
+            return sortedStages
         } catch {
             throw CloudKitError.invalidData(error.localizedDescription)
         }
@@ -126,13 +126,13 @@ final class CloudKitFetcherService {
         do {
             let wordRecords = try await fetchRecords(
                 recordType: CloudKitType.wordRecordType,
-                predicate: NSPredicate(format: "\(CloudKitField.stageReference.rawValue) == %@", stageRecord),
-                sortBy: CloudKitField.id.rawValue
+                predicate: NSPredicate(format: "\(CloudKitField.stageReference.rawValue) == %@", stageRecord)
             )
             
             let words = try await processRecordsConcurrently(wordRecords, transform: buildWord)
+            let sortedWords = words.sorted { $0.id < $1.id }
             print("[CloudKitFetcher] 단어 조회 완료 - 총 \(words.count)개")
-            return words
+            return sortedWords
         } catch {
             throw CloudKitError.invalidData(error.localizedDescription)
         }

--- a/YOZM/YOZM/Service/CloudKit/CloudKitFetcherService.swift
+++ b/YOZM/YOZM/Service/CloudKit/CloudKitFetcherService.swift
@@ -16,6 +16,23 @@ final class CloudKitFetcherService {
         self.publicDatabase = container.publicCloudDatabase
     }
     
+    func fetchAllChapters() async throws -> [Chapter] {
+        do {
+            let chapterRecords = try await fetchRecords(
+                recordType: CloudKitType.chapterRecordType,
+                predicate: NSPredicate(value: true),
+                sortBy: CloudKitField.id.rawValue
+            )
+            
+            let chapters = try await processRecordsConcurrently(chapterRecords, transform: buildChapter)
+            print("[CloudKitFetcher] 전체 챕터 조회 완료 - 총 \(chapters.count)개")
+            return chapters
+        } catch {
+            print("[CloudKitFetcher] 전체 챕터 조회 중 오류 발생: \(error.localizedDescription)")
+            throw error
+        }
+    }
+    
     func fetchChapter(by id: Int64) async throws -> Chapter {
         do {
             let chapterRecord = try await fetchRecord(
@@ -114,7 +131,7 @@ final class CloudKitFetcherService {
             )
             
             let words = try await processRecordsConcurrently(wordRecords, transform: buildWord)
-            print("[CloudKitFetcher] 단어 조회 완룼 - 총 \(words.count)개")
+            print("[CloudKitFetcher] 단어 조회 완료 - 총 \(words.count)개")
             return words
         } catch {
             throw CloudKitError.invalidData(error.localizedDescription)

--- a/YOZM/YOZM/View/Chapter/ChapterView.swift
+++ b/YOZM/YOZM/View/Chapter/ChapterView.swift
@@ -44,6 +44,9 @@ struct ChapterView: View {
         .ignoresSafeArea()
         .onAppear {
             UIScrollView.appearance().bounces = false
+            Task {
+                await viewModel.fetchData()
+            }
         }
         .onDisappear {
             UIScrollView.appearance().bounces = true

--- a/YOZM/YOZM/View/Chapter/ChapterView.swift
+++ b/YOZM/YOZM/View/Chapter/ChapterView.swift
@@ -44,6 +44,8 @@ struct ChapterView: View {
         .ignoresSafeArea()
         .onAppear {
             UIScrollView.appearance().bounces = false
+            
+            //TODO: 데이터 조회가 늦은 경우 화면 이동 막기
             Task {
                 await viewModel.fetchData()
             }

--- a/YOZM/YOZM/View/Chapter/ChapterViewModel.swift
+++ b/YOZM/YOZM/View/Chapter/ChapterViewModel.swift
@@ -11,6 +11,9 @@ import Foundation
 final class ChapterViewModel {
     private(set) var chapter: Chapter
     private(set) var latestCompleteWord: Word?
+    
+    private let cloudKitService: CloudKitService
+    
     var availableWords: [Int64: Bool] {
         var isAvailable = true
         var foundTarget: Bool = false
@@ -40,5 +43,14 @@ final class ChapterViewModel {
     init(chapter: Chapter = .sample) {
         self.chapter = chapter
         self.latestCompleteWord = nil
+        self.cloudKitService = CloudKitService.shared
+    }
+    
+    func fetchData() async {
+        do {
+            self.chapter = try await cloudKitService.fetchChapter(by: 1)
+        } catch {
+            print(error.localizedDescription)
+        }
     }
 }

--- a/YOZM/YOZM/View/WordStudy/SpeakingSentence/SpeakingSentenceView.swift
+++ b/YOZM/YOZM/View/WordStudy/SpeakingSentence/SpeakingSentenceView.swift
@@ -60,6 +60,11 @@ struct SpeakingSentenceView: View {
                 }
             }
         }
+        .onAppear{
+            Task {
+                await viewModel.loadAudio()
+            }
+        }
         .padding(.vertical, 24)
         .padding(.horizontal, 32)
         .frame(maxWidth: .infinity, maxHeight: 480)

--- a/YOZM/YOZM/View/WordStudy/SpeakingSentence/SpeakingSentenceViewModel.swift
+++ b/YOZM/YOZM/View/WordStudy/SpeakingSentence/SpeakingSentenceViewModel.swift
@@ -19,6 +19,7 @@ final class SpeakingSentenceViewModel {
     private let audioPlayerService: AudioPlayerService
     private let speechRecognitionService: SpeechRecognitionService
     private let pronunciationScoreService: PronunciationScoreService
+    private let cloudkitService: CloudKitService
 
     var transcription: String? {
         speechRecognitionService.result
@@ -37,6 +38,16 @@ final class SpeakingSentenceViewModel {
         self.audioPlayerService = AudioPlayerService.shared
         self.speechRecognitionService = SpeechRecognitionService.shared
         self.pronunciationScoreService = PronunciationScoreService.shared
+        self.cloudkitService = CloudKitService.shared
+    }
+    
+    func loadAudio() async {
+        do {
+            let url = try await cloudkitService.fetchSentenceAudioURL(wordId: word.id)
+            try audioPlayerService.load(url: url)
+        } catch {
+            print(error.localizedDescription)
+        }
     }
 
     func playAudio() {

--- a/YOZM/YOZM/View/WordStudy/WordDialogue/WordDialogueView.swift
+++ b/YOZM/YOZM/View/WordStudy/WordDialogue/WordDialogueView.swift
@@ -23,7 +23,7 @@ struct WordDialogueView: View {
         }
         .onAppear{
             Task {
-                await viewModel.loadAudio()
+                await viewModel.loadAndPlayAudioSequence()
             }
         }
     }

--- a/YOZM/YOZM/View/WordStudy/WordDialogue/WordDialogueView.swift
+++ b/YOZM/YOZM/View/WordStudy/WordDialogue/WordDialogueView.swift
@@ -21,6 +21,11 @@ struct WordDialogueView: View {
             partnerProfile
             chat
         }
+        .onAppear{
+            Task {
+                await viewModel.loadAudio()
+            }
+        }
     }
 
     private var partnerProfile: some View {

--- a/YOZM/YOZM/View/WordStudy/WordDialogue/WordDialogueViewModel.swift
+++ b/YOZM/YOZM/View/WordStudy/WordDialogue/WordDialogueViewModel.swift
@@ -11,6 +11,8 @@ import Foundation
 final class WordDialogueViewModel {
     private(set) var word: Word
     private(set) var dialogue: [Dialogue]
+    private(set) var isPlayingSequence: Bool = false
+    private var audioURLs: [URL] = []
     let finishAction: (() -> Void)?
     
     private let audioPlayerService: AudioPlayerService
@@ -27,24 +29,34 @@ final class WordDialogueViewModel {
         self.cloudkitService = CloudKitService.shared
     }
     
-    func loadAudio() async {
+    func loadAndPlayAudioSequence() async {
         do {
             let urls = try await cloudkitService.fetchDialogueAudioURLs(wordId: word.id)
-            for url in urls {
-                try audioPlayerService.load(url: url)
-                playAudio()
-            }
+            audioURLs = urls
+            
+            await playAudioSequence()
         } catch {
-            print(error.localizedDescription)
-        }
-    }
-
-    private func playAudio() {
-        do {
-            try audioPlayerService.play()
-        } catch {
-            print(error.localizedDescription)
+            print("오디오 로드 실패: \(error.localizedDescription)")
         }
     }
     
+    private func playAudioSequence() async {
+        guard !audioURLs.isEmpty else { return }
+        
+        isPlayingSequence = true
+        
+        for url in audioURLs {
+            do {
+                try audioPlayerService.load(url: url)
+                try await audioPlayerService.playAndWait()
+                
+                // 대화 간 간격
+                try await Task.sleep(for: .seconds(0.5))
+                
+            } catch {
+                print("오디오 재생 실패: \(error.localizedDescription)")
+            }
+        }
+        isPlayingSequence = false
+    }
 }

--- a/YOZM/YOZM/View/WordStudy/WordDialogue/WordDialogueViewModel.swift
+++ b/YOZM/YOZM/View/WordStudy/WordDialogue/WordDialogueViewModel.swift
@@ -9,14 +9,42 @@ import Foundation
 
 @Observable
 final class WordDialogueViewModel {
+    private(set) var word: Word
     private(set) var dialogue: [Dialogue]
     let finishAction: (() -> Void)?
+    
+    private let audioPlayerService: AudioPlayerService
+    private let cloudkitService: CloudKitService
 
     init(
         word: Word = Word.sampleWord,
         finishAction: (() -> Void)? = nil
     ) {
+        self.word = word
         self.dialogue = word.sampleDialogue
         self.finishAction = finishAction
+        self.audioPlayerService = AudioPlayerService.shared
+        self.cloudkitService = CloudKitService.shared
     }
+    
+    func loadAudio() async {
+        do {
+            let urls = try await cloudkitService.fetchDialogueAudioURLs(wordId: word.id)
+            for url in urls {
+                try audioPlayerService.load(url: url)
+                playAudio()
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+
+    private func playAudio() {
+        do {
+            try audioPlayerService.play()
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
 }

--- a/YOZM/YOZM/View/WordStudy/WordExplanation/WordExplanationView.swift
+++ b/YOZM/YOZM/View/WordStudy/WordExplanation/WordExplanationView.swift
@@ -16,10 +16,19 @@ struct WordExplanationView: View {
 
     var body: some View {
         VStack(spacing: 32) {
-            Text(viewModel.word.word)
-                .font(.title)
-                .bold()
-                .foregroundStyle(.blackNormal)
+            
+            VStack {
+                Text(viewModel.word.word)
+                    .font(.title)
+                    .bold()
+                    .foregroundStyle(.blackNormal)
+                
+                Text(viewModel.word.pronunciation)
+                    .font(.subheadline)
+                    .bold()
+                    .foregroundStyle(.blackNormal)
+            }
+            
             Text(viewModel.word.meaning)
                 .multilineTextAlignment(.leading)
                 .foregroundStyle(.blackNormal)

--- a/YOZM/YOZM/View/WordStudy/WritingSentence/WritingSentenceView.swift
+++ b/YOZM/YOZM/View/WordStudy/WritingSentence/WritingSentenceView.swift
@@ -50,6 +50,11 @@ struct WritingSentenceView: View {
                 )
             }
         }
+        .onAppear{
+            Task {
+                await viewModel.loadAudio()
+            }
+        }
         .padding(.vertical, 24)
         .padding(.horizontal, 32)
         .frame(maxWidth: .infinity, maxHeight: 480)

--- a/YOZM/YOZM/View/WordStudy/WritingSentence/WritingSentenceViewModel.swift
+++ b/YOZM/YOZM/View/WordStudy/WritingSentence/WritingSentenceViewModel.swift
@@ -18,6 +18,9 @@ final class WritingSentenceViewModel {
     }
 
     private let finishAction: (() -> Void)?
+    
+    private let audioPlayerService: AudioPlayerService
+    private let cloudkitService: CloudKitService
 
     init(word: Word = Word.sampleWord, finishAction: (() -> Void)? = nil) {
         self.word = word
@@ -26,18 +29,39 @@ final class WritingSentenceViewModel {
         self.text = ""
 
         self.finishAction = finishAction
+        self.cloudkitService = CloudKitService.shared
+        self.audioPlayerService = AudioPlayerService.shared
     }
 
     func setIsShowingHint(_ isShowingHint: Bool) {
         self.isShowingHint = isShowingHint
     }
 
+    func loadAudio() async {
+        do {
+            let url = try await cloudkitService.fetchSentenceAudioURL(wordId: word.id)
+            try audioPlayerService.load(url: url)
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+
     func playAudio() {
-        isPlaying = true
+        do {
+            try audioPlayerService.play()
+            isPlaying = true
+        } catch {
+            print(error.localizedDescription)
+        }
     }
 
     func stopAudio() {
-        isPlaying = false
+        do {
+            try audioPlayerService.stop()
+            isPlaying = false
+        } catch {
+            print(error.localizedDescription)
+        }
     }
 
     func setText(_ text: String) {


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #18

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- ChapterView에서 CloudKit 데이터 조회
- 오디오가 필요한 학습 화면에서 음성 데이터 조회 및 재생 처리(SpeakingSentenceView, WordDialogueView, WritingSentenceView)
- WordDialogueView에서 음성 연달아 재생 구현(AudioPlayerService에 음성 재생 완료되었는지 확인하는 로직 추가)

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 오디오 재생 확인
- [x] iPhone 16, iOS 18.3 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- WordDialogueView에서 텍스트가 보여지는 것과 음성 재생되는 시간이 매칭되지 않고 있는데, 이 부분은 테스트 같이 하면서 맞추면 좋을 것 같습니다.
- 현재는 ChapterView에서 CloudKit에 저장된 데이터를 다 불러와서 가지고 있는 로직인데, 이후에 SwiftData에 음성 제외한 텍스트 데이터를 저장하고 CloudKit 데이터와 비교하며 업데이트하는 로직으로 처리하려고 합니다!